### PR TITLE
Small Rendering improvement

### DIFF
--- a/SwiftNeoVim/NeoVimView+Draw.swift
+++ b/SwiftNeoVim/NeoVimView+Draw.swift
@@ -67,7 +67,7 @@ extension NeoVimView {
     let glyphPositions = positions.map { CGPoint(x: $0.x, y: $0.y + offset) }
 
     self.drawer.draw(
-      string,
+      string.precomposedStringWithCanonicalMapping,
       positions: UnsafeMutablePointer(mutating: glyphPositions), positionsCount: positions.count,
       highlightAttrs: rowFrag.attrs,
       context: context


### PR DESCRIPTION
> I'm currently reading MacVim source instead of going forward with these changes, but I want to save this message in case I do go forward with them

Hi.

While looking for a root cause of #482 & #283, I noticed that sometimes position was affecting whether a glyph would show up or not.

Later I found two issues regarding surrogate characters: one which causes the position to be shifted, and another which caused `lookupFont()` to receive invalid strings.

The solution I propose is to track the amount of glyphs rendered, based on `gatherGlyphs()`.
`recurseDraw()` signature was modified for the same reason.

This only seems to solve #482 though ...

